### PR TITLE
MAINT: Add support for Python 3.13, drop for 3.10

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/setup-piqtree
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache-key: libiqtree-ubuntu-latest-${{ needs.build-iqtree.outputs.iqtree2-sha }}
       
       - name: Install Docs Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14] # Intel linux, Intel Mac, ARM Mac
-        python-version: ["3.10", "3.11", "3.12"] 
+        python-version: ["3.11", "3.12", "3.13"] 
     steps:
       - uses: "actions/checkout@v4"
         with:
@@ -85,7 +85,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
         os: [ubuntu-latest]
 
     steps:
@@ -110,7 +110,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
 
       - uses: ./.github/actions/setup-piqtree
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache-key: libiqtree-ubuntu-latest-${{ needs.build-iqtree.outputs.iqtree2-sha }}
       
       - name: Install Docs Dependencies

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import os
 
 import nox
 
-_py_versions = range(9, 13)
+_py_versions = range(11, 14)
 
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "piqtree"
 dependencies = ["cogent3>=2024.11.29a2", "pyyaml", "requests"]
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.11, <3.14"
 
 authors = [{name="Gavin Huttley"}, {name="Robert McArthur"}, {name="Bui Quang Minh "}, {name="Richard Morris"}, {name="Thomas Wong"}]
 description="Python bindings for IQTree"


### PR DESCRIPTION
Addresses #171

Following [SPEC 0](https://scientific-python.org/specs/spec-0000/), support for Python 3.10 has been dropped.