### PR TITLE
MAINT: address cogent3 tree .traverse() deprecation

### DIFF
--- a/src/piqtree/iqtree/_tree.py
+++ b/src/piqtree/iqtree/_tree.py
@@ -352,7 +352,7 @@ def nj_tree(
     tree = make_tree(newick_tree)
 
     if not allow_negative:
-        for node in tree.traverse(include_self=False):
+        for node in tree.preorder(include_self=False):
             node.length = max(node.length, 0)
 
     return tree

--- a/tests/test_iqtree/test_nj_tree.py
+++ b/tests/test_iqtree/test_nj_tree.py
@@ -23,11 +23,11 @@ def test_nj_tree_allow_negative(all_otu: Alignment) -> None:
 
     # check that all branch lengths are non-negative, by default
     tree1 = nj_tree(dists)
-    assert all(node.length >= 0 for node in tree1.traverse(include_self=False))
+    assert all(node.length >= 0 for node in tree1.preorder(include_self=False))
 
     # check that some branch lengths are negative when allow_negative=True
     tree2 = nj_tree(dists, allow_negative=True)
-    assert any(node.length < 0 for node in tree2.traverse(include_self=False))
+    assert any(node.length < 0 for node in tree2.preorder(include_self=False))
 
 
 def test_nj_tree_nan(four_otu: Alignment) -> None:


### PR DESCRIPTION
[CHANGED] use preorder() instead