### PR TITLE
MAINT: Correct changleog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
 
 ## BUG
 
-- Pin build dependencies to workaround bug an upstream bug.
+- Pin build dependencies for reproducible builds and use new delvewheel `get_all_needed` API.
 
 ## DOC
 


### PR DESCRIPTION
Bug in building on windows was caused by changes to semi-private API in delvewheel, not pybind11.