### PR TITLE
Carry input bootstrap support onto consensus trees

### DIFF
--- a/docs/quickstart/construct_consensus_tree.md
+++ b/docs/quickstart/construct_consensus_tree.md
@@ -3,7 +3,8 @@
 A consensus tree can be constructed from a collection of `cogent3` tree objects with 
 [`consensus_tree`](../api/tree/consensus_tree.md). The method defaults to the majority-rule consensus 
 tree - though different minimum levels of support can be used to achieve the strict consensus tree, 
-and extended majority-rule consensus tree.
+and extended majority-rule consensus tree. By default, the support values of the input trees are 
+carried over onto the consensus tree (see [Bootstrap values](#bootstrap-values) below).
 
 ## Usage
 
@@ -53,6 +54,27 @@ tree4 = make_tree("(a,(c,(b,(d,e))));")
 tree5 = make_tree("(c,(b,(a,(d,e))));")
 
 tree = consensus_tree([tree1, tree2, tree3, tree4, tree5], min_support=0) # (a,((b,c),(d,e)));
+```
+
+### Bootstrap values
+
+When the input trees carry their own branch support - for example, the ultrafast bootstrap support
+produced by [`build_tree`](construct_ml_tree.md) - `consensus_tree` carries these values over onto
+the matching clades of the consensus tree, averaged across the input trees that contain each clade.
+The way the values are combined is set by `support_aggregate` (`"mean"` by default, or `"max"` /
+`"min"`), and each node's value can be accessed from `#!py3 node.support`.
+
+```python
+from cogent3 import make_tree
+from piqtree import consensus_tree
+
+# the numbers on the internal nodes are each tree's own bootstrap support
+tree1 = make_tree("(a,((b,c)96,(d,e)90));")
+tree2 = make_tree("(a,((b,c)88,(d,e)70));")
+
+tree = consensus_tree([tree1, tree2])  # support_aggregate="mean" by default
+# (b,c) -> mean(96, 88) -> 92.0
+# (d,e) -> mean(90, 70) -> 80.0
 ```
 
 ## See also

--- a/src/piqtree/iqtree/_tree.py
+++ b/src/piqtree/iqtree/_tree.py
@@ -1,6 +1,7 @@
 """Python wrappers to tree searching functions in the IQ-TREE library."""
 
-from collections.abc import Iterable, Sequence
+import statistics
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, cast
 
 import numpy as np
@@ -289,10 +290,49 @@ def _all_same_taxa_set(trees: Iterable[PhyloNode]) -> bool:
     return all(taxa_set == set(tree.get_tip_names()) for tree in tree_it)
 
 
+_SUPPORT_AGGREGATES: dict[str, Callable[[Iterable[float]], float]] = {
+    "mean": statistics.mean,
+    "max": max,
+    "min": min,
+}
+
+
+def _transfer_support(
+    consensus: PhyloNode,
+    trees: Iterable[PhyloNode],
+    aggregate: Callable[[Iterable[float]], float],
+) -> None:
+    """Set each consensus clade's support from the input trees' support for the same split."""
+    taxa = frozenset(consensus.get_tip_names())
+    reference = min(taxa)
+
+    def split_key(node: PhyloNode) -> frozenset[str]:
+        side = frozenset(node.get_tip_names())
+        return taxa - side if reference in side else side
+
+    lookup: dict[frozenset[str], list[float]] = {}
+    for tree in trees:
+        for node in tree.postorder():
+            if node.is_tip() or node.is_root():
+                continue
+            support = getattr(node, "support", None)
+            if support is None:
+                continue
+            lookup.setdefault(split_key(node), []).append(support)
+
+    for node in consensus.postorder():
+        if node.is_tip() or node.is_root():
+            continue
+        values = lookup.get(split_key(node))
+        if values:
+            node.support = aggregate(values)
+
+
 def consensus_tree(
     trees: Iterable[PhyloNode],
     *,
     min_support: float = 0.5,
+    support_aggregate: str | None = "mean",
 ) -> PhyloNode:
     """Build a consensus tree, defaults to majority-rule consensus tree.
 
@@ -302,6 +342,9 @@ def consensus_tree(
     If min_support is 1.0, computes the strict consensus tree.
     If min_support is 0.0, computes the extended majority-rule consensus tree.
 
+    By default the input trees' own support values are transferred onto
+    matching consensus clades.
+
     Parameters
     ----------
     trees : Iterable[PhyloNode]
@@ -309,6 +352,10 @@ def consensus_tree(
     min_support : float, optional
         The minimum support for a clade to appear
         in the consensus tree, by default 0.5.
+    support_aggregate : str | None, optional
+        How to combine the input trees' support for a shared clade.
+        One of "mean" (default), "max", "min". If None, the consensus'
+        own clade-frequency support is kept and the input support ignored.
 
     Returns
     -------
@@ -320,10 +367,22 @@ def consensus_tree(
         msg = f"Only min support values in the range 0 <= value <= 1 are supported, got {min_support}"
         raise ValueError(msg)
 
+    if support_aggregate is not None and support_aggregate not in _SUPPORT_AGGREGATES:
+        allowed = ", ".join(sorted(_SUPPORT_AGGREGATES))
+        msg = f"support_aggregate must be one of {allowed} or None, got {support_aggregate!r}"
+        raise ValueError(msg)
+
+    trees = list(trees)
+
     if not _all_same_taxa_set(trees):
         msg = "Trees must be on same taxa set."
         raise ValueError(msg)
 
     newick_trees = [get_newick(tree) for tree in trees]
 
-    return make_tree(iq_consensus_tree(newick_trees, min_support))
+    consensus = make_tree(iq_consensus_tree(newick_trees, min_support))
+
+    if support_aggregate is not None:
+        _transfer_support(consensus, trees, _SUPPORT_AGGREGATES[support_aggregate])
+
+    return consensus

--- a/tests/test_iqtree/test_consensus_tree.py
+++ b/tests/test_iqtree/test_consensus_tree.py
@@ -104,3 +104,73 @@ def test_bad_trees(trees: Iterable[PhyloNode]) -> None:
 def test_no_trees() -> None:
     with pytest.raises(IqTreeError):
         consensus_tree([])
+
+
+def _internal_supports(tree: PhyloNode) -> dict[frozenset, float]:
+    return {
+        frozenset(node.get_tip_names()): node.support
+        for node in tree.postorder()
+        if not node.is_tip() and not node.is_root()
+    }
+
+
+@pytest.mark.parametrize(
+    ("aggregate", "expected_ab", "expected_de"),
+    [
+        ("mean", 93.0, 79.0),
+        ("max", 95.0, 88.0),
+        ("min", 91.0, 70.0),
+    ],
+)
+def test_support_aggregate(
+    aggregate: str,
+    expected_ab: float,
+    expected_de: float,
+) -> None:
+    # inputs are rooted differently to the consensus, so matching is by bipartition
+    tree1 = make_tree("(((a:1,b:1)95:1,c:1)88:1,d:1,e:1);")
+    tree2 = make_tree("(((a:1,b:1)91:1,c:1)70:1,d:1,e:1);")
+
+    got = consensus_tree([tree1, tree2], support_aggregate=aggregate)
+    supports = _internal_supports(got)
+
+    assert supports[frozenset({"c", "d", "e"})] == expected_ab  # {a,b}|{c,d,e}
+    assert supports[frozenset({"d", "e"})] == expected_de  # {a,b,c}|{d,e}
+
+
+def test_support_aggregate_default_is_mean() -> None:
+    tree1 = make_tree("(((a:1,b:1)95:1,c:1)88:1,d:1,e:1);")
+    tree2 = make_tree("(((a:1,b:1)91:1,c:1)70:1,d:1,e:1);")
+
+    supports = _internal_supports(consensus_tree([tree1, tree2]))
+    assert supports[frozenset({"c", "d", "e"})] == 93.0
+    assert supports[frozenset({"d", "e"})] == 79.0
+
+
+def test_support_aggregate_none_keeps_clade_frequency() -> None:
+    tree1 = make_tree("(((a:1,b:1)95:1,c:1)88:1,d:1,e:1);")
+    tree2 = make_tree("(((a:1,b:1)91:1,c:1)70:1,d:1,e:1);")
+
+    got = consensus_tree([tree1, tree2], support_aggregate=None)
+    assert set(_internal_supports(got).values()) == {100.0}
+
+
+def test_support_aggregate_clade_absent_from_inputs() -> None:
+    # inputs have no support, so consensus keeps its clade-frequency value
+    tree1 = make_tree("(((a,b),c),d,e);")
+    tree2 = make_tree("(((a,b),c),d,e);")
+
+    got = consensus_tree([tree1, tree2], support_aggregate="mean")
+    assert set(_internal_supports(got).values()) == {100.0}
+
+
+@pytest.mark.parametrize("aggregate", ["median", "average", "MEAN", ""])
+def test_bad_support_aggregate(
+    five_trees: list[PhyloNode],
+    aggregate: str,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match=re.escape("support_aggregate must be one of"),
+    ):
+        consensus_tree(five_trees, support_aggregate=aggregate)


### PR DESCRIPTION
`consensus_tree()` previously discarded the input trees' branch support. This meant ultrafast bootstrap support from build_tree was lost in the consensus.

This PR adds a support_aggregate parameter (default "mean") that transfers each input tree's own support onto the matching clades of the consensus, aggregated across the trees that contain each clade. Matching is done by bipartition, so it is robust to the trees being rooted differently. Pass support_aggregate=None to keep the previous clade-frequency behaviour.

Changes:
- consensus_tree: new support_aggregate keyword ("mean" | "max" | "min" | None).
- Tests covering the default, each aggregation, and invalid values.
- Quickstart doc updated with a short "Bootstrap values" section.

Notes:
- Pure Python change — the IQ-TREE C++ code is untouched.
- node.support carries the values
